### PR TITLE
Update badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [badges]
-travis-ci = { repository = "otavio/easy-process-rs" }
+coveralls = { repository = "ossystems/easy-process-rs" }
 
 [dependencies]
 checked_command = "0.2.2"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://travis-ci.org/otavio/easy-process-rs.svg?branch=master)](https://travis-ci.org/otavio/easy-process-rs) [![Documentation](https://docs.rs/easy_process/badge.svg)](https://docs.rs/easy_process)
+![Continuous integration](https://github.com/OSSystems/easy-process-rs/workflows/Continuous%20integration/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/OSSystems/easy-process-rs/badge.svg?branch=master)](https://coveralls.io/github/OSSystems/easy-process-rs?branch=master)
+[![Documentation](https://docs.rs/easy_process/badge.svg)](https://docs.rs/easy_process)
 
 # easy_process
 

--- a/README.tpl
+++ b/README.tpl
@@ -1,4 +1,6 @@
-[![Build Status](https://travis-ci.org/otavio/easy-process-rs.svg?branch=master)](https://travis-ci.org/otavio/easy-process-rs) [![Documentation](https://docs.rs/easy_process/badge.svg)](https://docs.rs/easy_process)
+![CI](https://github.com/OSSystems/compress-tools-rs/workflows/Rust/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/OSSystems/compress-tools-rs/badge.svg?branch=master)](https://coveralls.io/github/OSSystems/compress-tools-rs?branch=master)
+[![Documentation](https://docs.rs/compress-tools/badge.svg)](https://docs.rs/compress-tools)
 
 # {{crate}}
 


### PR DESCRIPTION
We should also be able to have Github Action's badge on Cargo.toml once https://github.com/rust-lang/crates.io/pull/1838 gets merged

Signed-off-by: Jonathas-Conceicao <jonathas.conceicao@ossystems.com.br>