### PR TITLE
ci: Replace no-leading-pads with panic=abort

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -76,7 +76,7 @@ jobs:
           args:  --all --all-features --no-fail-fast -- --nocapture
         env:
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
+          RUSTFLAGS: '-Zprofile -Zpanic_abort_tests -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort'
       - id: coverage
         if: matrix.version == 'nightly'
         uses: actions-rs/grcov@master


### PR DESCRIPTION
Replacing `-Zno-leading-pads` with `-Cpanic=abort` due to https://github.com/rust-lang/rust/pull/70175